### PR TITLE
add get_os_interface

### DIFF
--- a/lib/openstack/compute/address.rb
+++ b/lib/openstack/compute/address.rb
@@ -20,18 +20,24 @@ module Compute
 
   class Address
 
+    attr_reader :mac_addr
+    attr_reader :type
     attr_reader :address
     attr_reader :label
     attr_reader :version
 
-    def initialize(label, address, version = 4)
+    def initialize(label, address, version = 4, mac_addr = nil, type = nil)
       @label = label
       if address.class == Hash then
-        @address = address["addr"]
-        @version = address["version"]
+        @address  = address["addr"]
+        @version  = address["version"]
+        @mac_addr = address["OS-EXT-IPS-MAC:mac_addr"]
+        @type     = address["OS-EXT-IPS:type"]
       else
-        @address = address
-        @version = version
+        @address  = address
+        @version  = version
+        @mac_addr = mac_addr
+        @type     = type
       end
     end
 

--- a/lib/openstack/compute/connection.rb
+++ b/lib/openstack/compute/connection.rb
@@ -3,6 +3,8 @@ module Compute
 
   class Connection
 
+    require 'openstack/compute/os_interface'
+
     attr_accessor   :connection
     attr_accessor   :extensions
 
@@ -493,6 +495,14 @@ module Compute
       check_extension 'os-floating-ips-bulk'
       response = @connection.req('POST', '/os-floating-ips-bulk/delete', {:data => data})
       res = JSON.generate(response)
+    end
+
+    def get_os_interface(server_id)
+      path = "/servers/#{URI.encode(server_id.to_s)}/os-interface"
+      response = @connection.req("GET", path)
+      JSON.parse(response.body)["interfaceAttachments"].map do |hash|
+        OpenStack::Compute::OsInterface.new(hash)
+      end
     end
 
     private

--- a/lib/openstack/compute/os_interface.rb
+++ b/lib/openstack/compute/os_interface.rb
@@ -1,0 +1,19 @@
+module OpenStack
+module Compute
+  class OsInterface
+    attr_reader :fixed_ip
+    attr_reader :mac_addr
+    attr_reader :net_id
+    attr_reader :port_id
+    attr_reader :port_state
+
+    def initialize(addr_hash)
+      @fixed_ips  = addr_hash["fixed_ips"]
+      @mac_addr   = addr_hash["mac_addr"]
+      @net_id     = addr_hash["net_id"]
+      @port_id    = addr_hash["port_id"]
+      @port_state = addr_hash["port_state"]
+    end
+  end
+end
+end

--- a/lib/openstack/compute/os_interface.rb
+++ b/lib/openstack/compute/os_interface.rb
@@ -1,7 +1,7 @@
 module OpenStack
 module Compute
   class OsInterface
-    attr_reader :fixed_ip
+    attr_reader :fixed_ips
     attr_reader :mac_addr
     attr_reader :net_id
     attr_reader :port_id


### PR DESCRIPTION
OSのInterface情報を取得できるようにmethodを追加

呼び方

``` ruby
Connection.new( ..... ). get_os_interface( server_id )
# => [#<OpenStack::Compute::OsInterface:0x007fba8aa6de10 @fixed_ips=[{"subnet_id"=>"e75c5058-ef24-4db2-b696-c6bd79be0566", "ip_address"=>"192.168.9.47"}], @mac_addr="fa:16:3e:0c:b6:cc", @net_id="c7136695-0090-4ad7-b446-2f9f32a331f6", @port_id="4f224a59-f7e1-4e6f-832e-a75be672a458", @port_state="ACTIVE">]
```
